### PR TITLE
Updating Sceptre Version to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
+## 2.0.0 (2023/02/04)
+
+### Changed
+- Updated required Sceptre Version to 4.0
+- Migrated to using the recommended way of obtaining session environment variables for running the
+  cdk-assets subprocess.
+
 ## 1.0.0 (2022/11/28)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # CHANGELOG
-
 Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest>=7.0.0
 pytest-subtests
 readme-renderer>=24.0
 setuptools>=40.6.2
-sceptre>=2.7
+sceptre>=4.0
 tox>=2.9.1,<3.0.0
 twine>=1.12.1
 wheel==0.32.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 2.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"
 
 # More information on setting values:
 # https://github.com/Sceptre/project/wiki/sceptre-template-handler-template
@@ -25,7 +25,7 @@ with open("README.md") as readme_file:
     README = readme_file.read()
 
 install_requirements = [
-    "sceptre>=2.7",
+    "sceptre>=4.0",
     "aws_cdk-lib>=2.0,<3.0",
     "cdk-bootstrapless-synthesizer>=2.0,<3.0",
     "typing-extensions"
@@ -64,7 +64,10 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Environment :: Console",
-        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     test_suite="tests",
     install_requires=install_requirements,


### PR DESCRIPTION
This updates the base version of Sceptre to v4. This will remove DeprecationWarnings that it otherwise would be triggering through accessing `iam_role`. 

This cannot be released until Sceptre v4 is released. Tests will not pass until v4 has been released.