### PR TITLE
Update pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -17,14 +17,16 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.86.0
+    rev: v1.2.5.a10
     hooks:
       - id: cfn-python-lint
         args:
           - "-i=E0000"
           - "-i=E1001"
           - "-i=E3012"
+          - "-i=E1019"
           - "-i=W6001"
+          - "-i=W2031"
         exclude: |
           (?x)(
             ^integration-tests/sceptre-project/config/|
@@ -36,7 +38,7 @@ repos:
             ^.pre-commit-config.yaml
           )
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 24.4.2
     hooks:
       - id: black
   - repo: https://github.com/python-poetry/poetry
@@ -47,7 +49,7 @@ repos:
         language_version: python3.10
         args: ['--check']
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.28.0
+    rev: 0.28.5
     hooks:
       - id: check-github-workflows
       - id: check-github-actions


### PR DESCRIPTION
ignore the following errors..

```
AWS CloudFormation Linter................................................Failed
- hook id: cfn-python-lint
- exit code: 6

W2031 '' does not match 'arn:(aws[a-zA-Z-]*)?:iam::(\\d{12}|aws):policy/[a-zA-Z_0-9+=,.@\\-_/]+' when 'Ref' is resolved
sceptre-example/templates/cdk-bootstrap.yaml:21:5

E1019 {'Fn::Sub': '${FileAssetsBucketName}'} is shorter than 3 when 'Fn::Sub' is resolved
sceptre-example/templates/cdk-bootstrap.yaml:178:13

E1019 {'Fn::Sub': '${FileAssetsBucketName}'} does not match '^[a-z0-9][a-z0-9.-]*[a-z0-9]$' when 'Fn::Sub' is resolved
sceptre-example/templates/cdk-bootstrap.yaml:178:13

E1019 {'Fn::Sub': '${ContainerAssetsRepositoryName}'} is shorter than 2 when 'Fn::Sub' is resolved
sceptre-example/templates/cdk-bootstrap.yaml:230:13

E1019 {'Fn::Sub': '${ContainerAssetsRepositoryName}'} does not match '^(?=.{2,256}$)((?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*)$' when 'Fn::Sub' is resolved
sceptre-example/templates/cdk-bootstrap.yaml:230:13
```
